### PR TITLE
Add egg for additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [
-          "git+https://github.com/PyCQA/pyflakes",
-          "git+https://gitlab.com/PyCQA/pycodestyle",
+          "git+https://github.com/PyCQA/pyflakes#egg=pyflakes",
+          "git+https://gitlab.com/PyCQA/pycodestyle#egg=pycodestyle",
         ]


### PR DESCRIPTION
Fixes errors from pre-commit; workaround for https://github.com/pre-commit/pre-commit/issues/1238.

Inspired by a [pre-commit config](https://github.com/unmade/dokusan/blob/ea8f691d193530a885d7c30e41e6c1467ccdbbdf/.pre-commit-config.yaml) found via a [GitHub search](https://github.com/search?q=filename%3Apre-commit-config+flake8+pyflakes+pycodestyle).